### PR TITLE
Make name of logging selector env var consistent across all containers. Closes #38

### DIFF
--- a/docs/installing_daemons.md
+++ b/docs/installing_daemons.md
@@ -80,7 +80,7 @@ e.g., `hermes`, `kronos`,
 Any additional command line parameter can be specified here, e.g.,
 `\--run-once` This field is optional.
 
-### RUCIO_ENABLE_LOGFILE
+### RUCIO_ENABLE_LOGS
 
 By default, the log output of the daemon is written to stdout and
 stderr. If you set this variable to `True` the output will

--- a/docs/installing_server.md
+++ b/docs/installing_server.md
@@ -90,7 +90,7 @@ it can be done using the `RUCIO_ENABLE_LOGS` variable. The
 storage folder of the logs can be used as a volume:
 
 ```bash
-docker run --name=rucio-server -v /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg -v /tmp/logs:/var/log/httpd -p 80:80 -e RUCIO_ENABLE_LOGFILE=True -d rucio/rucio-server
+docker run --name=rucio-server -v /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg -v /tmp/logs:/var/log/httpd -p 80:80 -e RUCIO_ENABLE_LOGS=True -d rucio/rucio-server
 ```
 
 ## Environment Variables
@@ -125,7 +125,7 @@ of aliases you can set this variable to `True`. The web
 server then expects an alias file under
 `/opt/rucio/etc/aliases.conf`
 
-### RUCIO_ENABLE_LOGFILE
+### RUCIO_ENABLE_LOGS
 
 By default, the log output of the web server is written to stdout and
 stderr. If you set this variable to `True` the output will


### PR DESCRIPTION
https://github.com/rucio/documentation/issues/38