### PR TITLE
Fix broken internal links

### DIFF
--- a/docs/Replica-management.md
+++ b/docs/Replica-management.md
@@ -5,7 +5,7 @@ title: Replica management with replication rules
 Replica management is based on replication rules defined on data
 identifiers (files, datasets, containers). A replication rule is owned
 by an account and defines the minimum number of replicas to be available
-on a list of RSEs, denoted by an [RSE Expression](rse_expressions.html).
+on a list of RSEs, denoted by an [RSE Expression](rse_expressions.md).
 Accounts are allowed to set multiple rules[^1]. Rules may optionally
 have a limited lifetime and can be added, removed or modified at any
 time.
@@ -37,7 +37,7 @@ deletion. The deletion service will also immediately delete all replicas
 of any file which is declared obsolete.
 
 Some examples of replication rules are listed
-[here](replication_rules_examples.html).
+[here](replication_rules_examples.md).
 
 ## Footnotes
 

--- a/docs/Rucio_storage_element.md
+++ b/docs/Rucio_storage_element.md
@@ -13,7 +13,7 @@ non-pledged space), and geographical zone.
 Rucio Storage Elements can be grouped in many logical ways, e.g. the UK
 RSEs, the Tier-1 RSEs, or the \'good\' RSEs. One can reference groups of
 RSEs by metadata attributes or by explicit enumeration of RSEs. See the
-section about [RSE Expressions](rse_expressions.html) for more
+section about [RSE Expressions](rse_expressions.md) for more
 information.
 
 RSE tags are expanded at transfer time to enumerate target sites.
@@ -33,5 +33,5 @@ about replica location on volatile RSEs can have a lifetime. Replicas
 registered on volatile RSEs are excluded from the Rucio replica
 management system (replication rules, quota, replication locks)
 described in the section [Replica
-management](overview_Replica_management.html). Explicit transfer
+management](overview_Replica_management.md). Explicit transfer
 requests can be made to Rucio in order to populate the cache.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ sidebar_label: Configuration
 
 ## Prerequisites
 
-You need to have a Rucio server up and running with the root account created. Please refer to [installation documentation](installing_server.html) for further information
+You need to have a Rucio server up and running with the root account created. Please refer to [installation documentation](installing_server.md) for further information
 
 ## Creating new users
 

--- a/docs/replica-workflow.md
+++ b/docs/replica-workflow.md
@@ -6,7 +6,7 @@ sidebar_label: Typical Replica Workflow
 
 This section gives an overview of what happens within Rucio, for a typical replica workflow. Two workflows are described:
 When a replica is uploaded to Rucio via a client and when a replica is created by a
-site to site transfer due to the creation of a [replication rule](overview_Replica_management.html).
+site to site transfer due to the creation of a [replication rule](overview_Replica_management.md).
 
 ##Replica paths on storage
 
@@ -46,7 +46,7 @@ For the data identifier `user.jdoe:test.file.1` which is part of the dataset `da
 This is a typical workflow when a user uploads multiple files, which are part of a dataset, via the command line client.
 
 1. The dataset `test.dataset` is being registered at the server.
-   All files, or datasets are associated to a [scope](overview_File_Dataset_Container.html), if not specifically mentioned the client will assume the default scope of the user,
+   All files, or datasets are associated to a [scope](overview_File_Dataset_Container.md), if not specifically mentioned the client will assume the default scope of the user,
    such as `user.jdoe`. Thus the full data identifier for the dataset is `user.jdoe:test.dataset`.
 
 

--- a/docs/replication_rules_examples.md
+++ b/docs/replication_rules_examples.md
@@ -11,12 +11,12 @@ representing the numbers of replicas wanted and a Rucio Storage Element
 Expression that allows to select a set of probable RSEs to store the
 replicas.
 
-The [__RSE Expression__](rse_expressions.html) gets resolved into a set of
+The [__RSE Expression__](rse_expressions.md) gets resolved into a set of
 RSEs, which are possible destination RSEs for the number of replicas the
 user wants to create.
 
 Is possible to find detailed information and examples about how to write
-RSE Expressions [__here__](rse_expressions.html).
+RSE Expressions [__here__](rse_expressions.md).
 
 ## Example 1
 


### PR DESCRIPTION
Several links reference to internal `.html` files, which are not supported anymore. `.md` should be used instead.

Closes #40