### PR TITLE
Fix deprecated example

### DIFF
--- a/docs/replication_rules_examples.md
+++ b/docs/replication_rules_examples.md
@@ -34,7 +34,7 @@ To see all the possible targets, **rucio list-rses** command can be
 used:
 
 ```bash
-username@host:~$ rucio list-rses --expression 'tier=1'
+username@host:~$ rucio list-rses --rses 'tier=1'
 ```
 
 ## Example 2


### PR DESCRIPTION
This is a fairly minor edit but if I copy the documented command rucio tells me that this is a deprecated option. So I guess it is better to fix it in the docs :) 