### PR TITLE
Add information on how to install `pre-push` hooks

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,6 +83,15 @@ pip install pre-commit
 pre-commit install
 ```
 
+If you only want to run the hooks on a push, run:
+
+```bash
+pre-commit install --hook-type pre-push
+```
+
+More information:
+<https://pre-commit.com/#confining-hooks-to-run-at-certain-stages>
+
 ## Contributing
 
 **Step 1**: If not exist, create an


### PR DESCRIPTION
The `pre-commit` hooks can also be run as `pre-push` hooks. Some developers have
intermediate commits, on which the hooks should not run.