### PR TITLE
Ignore emacs auto-generated files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# -*- mode: gitignore; -*-
 node_modules/
 /website/translated_docs
 /website/build/
@@ -14,3 +15,52 @@ node_modules/
 /docs/bin
 /docs/bin.md
 /docs/release-notes.md
+
+# emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data


### PR DESCRIPTION
Emacs creates temporary files which should not be commited to the
repository. This commit adds all of them to the `.gitignore` file.

More information:
Created by https://www.toptal.com/developers/gitignore/api/emacs
Edit at https://www.toptal.com/developers/gitignore?templates=emacs