### PR TITLE
Change the Rest Api format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 /docs/bin
 /docs/bin.md
 /docs/release-notes.md
+/docs/rest_api_doc_spec.yaml
 
 # emacs
 *~

--- a/rucio-generate-doc.py
+++ b/rucio-generate-doc.py
@@ -132,7 +132,7 @@ def main():
         image_list[0],
         "sh",
         "-c",
-        "tools/test/install_script.sh && tools/generate_doc.py",
+        "tools/test/install_script.sh && tools/generate_doc.py && tools/generate_rest_api_doc.py > docs/rest_api_doc_spec.yaml && pwd",
         _in=sys.stdin,
         _out=sys.stdout,
         _err=sys.stderr,
@@ -148,6 +148,9 @@ def main():
     assert os.path.exists(templates_dir)
     render_templates(templates_dir, output_path)
 
+    # build rest api documentation
+    os.system('npx --yes redoc-cli bundle docs/rest_api_doc_spec.yaml')
+    os.system('mkdir -p website/static/html && cp redoc-static.html website/static/html/rest_api_doc.html')
 
 if __name__ == "__main__":
     main()

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,7 +36,7 @@ module.exports={
           "routeBasePath": "/",
           "sidebarPath": "../website/sidebars.json",
           'editUrl': 'https://github.com/rucio/documentation/tree/main/docs',
-        },        
+        },
         "blog": {},
         "theme": {
           "customCss": "../src/css/customTheme.css"
@@ -44,7 +44,7 @@ module.exports={
       }
     ]
   ],
-  "plugins": [], 
+  "plugins": [],
   "themeConfig": {
     "navbar": {
       "title": "Rucio Documentation",
@@ -59,7 +59,7 @@ module.exports={
           "position": "left"
         },
         {
-          "to": "rucio_rest_api",
+          "to": "pathname:///html/rest_api_doc.html",
           "label": "REST API",
           "position": "left"
         }

--- a/website/static/html/.gitignore
+++ b/website/static/html/.gitignore
@@ -1,0 +1,1 @@
+rest_api_doc.html


### PR DESCRIPTION
rucio/rucio#4992 intruduces the new Rest Api format OpenApi. This commit links the newly generated html file instead of the old generated one.