### PR TITLE
Delete the `Miscellaneous` sidebar entry

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -23,18 +23,14 @@
       "database",
       "administration",
       "configuration_parameters",
-      "configure-rucio-globus"
+      "configure-rucio-globus",
+      "policy_packages"
     ],
     "Developer": [
       "setting_up_demo",
       "developing_with_rucio",
       "contributing",
       "component_leads"
-    ],
-    "Miscellaneous": [
-      "policy_packages",
-      "notifications",
-      "metadata_attributes"
     ],
     "About Us": [
       "about_our_contributors",


### PR DESCRIPTION
The `Miscellaneous` sidebar entry does not make any sence. The entries are
either conecpts or server related.

This commit splits the `Miscellaneous` sidebar entry to thier respective correct
entry.