### PR TITLE
Change the portrait of the release notes list #119

### DIFF
--- a/tools/generate_release_notes_index.py
+++ b/tools/generate_release_notes_index.py
@@ -1,19 +1,44 @@
 #!/usr/bin/env python3
-import jinja2
-import pathlib
 import os
+import pathlib
+import re
+from collections import defaultdict
+from typing import Dict, List
+
+import jinja2
+
+MAJOR_VERSION = re.compile(r"(\d+)\.\d+\.\d+")
+MINOR_VERSION = re.compile(r"\d+\.(\d+)\.\d+")
+PATCH_VERSION = re.compile(r"\d+\.\d+\.(\d+)")
+MAJOR_MINOR_VERSION = re.compile(r"(\d+\.\d+)\.\d+")
+
 
 def render_templates(templates_dir: str, output_path: pathlib.Path):
     def index_item(path: pathlib.Path):
         return {"stem": path.stem, "path": str(path.relative_to(output_path))}
 
-    def index_func(path: str):
+    def index_func(path: str) -> Dict[str, List[Dict]]:
         path = output_path / path
         if not str(path).startswith(str(output_path)):
             raise ValueError("path may not escape the output path")
         if not path.exists():
             raise ValueError(f"cannot index: {path} does not exist")
-        yield from map(index_item, path.iterdir())
+
+        items = path.iterdir()
+
+        mapped_items = defaultdict(list)
+        for i in items:
+            mapped_items[MAJOR_MINOR_VERSION.match(i.stem).group(1)].append(
+                {
+                    "major_version_number": int(MAJOR_VERSION.match(i.stem).group(1)),
+                    "minor_version_number": int(MINOR_VERSION.match(i.stem).group(1)),
+                    "patch_version_number": int(PATCH_VERSION.match(i.stem).group(1)),
+                    "stem": i.stem,
+                    "path": str(i.relative_to(output_path))
+                }
+            )
+
+        return mapped_items
 
     jinja_env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(templates_dir)

--- a/tools/templates/release-notes.md.j2
+++ b/tools/templates/release-notes.md.j2
@@ -6,6 +6,15 @@ sidebar_label: Release Notes
 Below listed are all the release notes from the very first release
 uptil the latest one:
 
-{% for file in index("release-notes") | sort(attribute="stem", reverse=True) -%}
-- [{{ file.stem }}]({{ file.path }})
+{% for group, items in index("release-notes") | dictsort(reverse = True) %}
+## {{ group }}
+
+{% for item in items
+  | sort(
+    reverse = True,
+    attribute = "major_version_number,minor_version_number,patch_version_number,stem"
+  ) -%}
+- [{{ item['stem'] }}]({{item['path']}})
+{% endfor -%}
+
 {% endfor %}


### PR DESCRIPTION
The release notes list is a list on a dedicated page containing a
reference to all the release notes. This list has reacht a certain size
and contains two problems:

- The items are sorted via the string type. This means, that the version
  string `1.26.11` is logically _smaller_ than `1.26.2`.

- It is to big to easily find the appropriate content. It should be
  grouped to find the desired item more easily.

The release notes list is now grouped by the minor version number and
the sort is logically coherent.