### PR TITLE
Let git ignore the static html file

### DIFF
--- a/website/static/html/.gitignore
+++ b/website/static/html/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore


### PR DESCRIPTION
Static generated files should not be tracked by git. There is no reason
why the `website/static/html` files should be in our versioning system.