### PR TITLE
Make the rest_api_doc_spec.yaml file available as asset

### DIFF
--- a/tools/build_documentation.sh
+++ b/tools/build_documentation.sh
@@ -17,9 +17,11 @@ sudo chown -R "$USER":"$USER" "$AUTO_GENERATED"
 
 echo "Generating Rest Api Docs from Spec File..."
 npx --yes redoc-cli build "$AUTO_GENERATED"/rest_api_doc_spec.yaml --output "$AUTO_GENERATED"/rest_api_doc.html
+
+mkdir -p "$SCRIPT_DIR"/../website/static/yaml/
 mkdir -p "$SCRIPT_DIR"/../website/static/html/
 
-
+cp -r "$AUTO_GENERATED"/rest_api_doc_spec.yaml "$SCRIPT_DIR"/../website/static/yaml/
 cp -r "$AUTO_GENERATED"/rest_api_doc.html "$SCRIPT_DIR"/../website/static/html/
 cp -r "$AUTO_GENERATED"/client_api "$DOCS"
 cp -r "$AUTO_GENERATED"/bin "$DOCS"

--- a/website/static/yaml/.gitignore
+++ b/website/static/yaml/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore


### PR DESCRIPTION
The `rest_api_doc_spec.yaml` file is auto-generated from the rucio
project and is used to create the Rest Api Docs. Making the spec file
available allows users to access and reference it directly, instead of
creating it on their own. This allows them to e.g. use different
front-ends or analyze the file.