### PR TITLE
Database: document the poolclass option in rucio.cfg

### DIFF
--- a/docs/about_our_contributors.md
+++ b/docs/about_our_contributors.md
@@ -63,6 +63,7 @@ repository](https://github.com/rucio/documentation) before making a submission.
 - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 - Rob Barnsley <R.Barnsley@skatelescope.org>, 2020
 - Alan Malta Rodrigues <alan.malta@cern.ch>, 2020
+- Aksel Lunde Aase <aksel.lunde.aase@gmail.com>, 2022
 
 # Organisations employing contributors
 

--- a/docs/configuration_parameters.md
+++ b/docs/configuration_parameters.md
@@ -232,6 +232,9 @@ attributes.
     <https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_size>
   - **pool_timeout**:
     <https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_timeout>
+  - **poolclass**: Which connection pooling mechanism to use. Values: `nullpool` (disables pooling),
+    `queuepool` (default for all but SQLite engine), or `singletonthreadpool` (default for SQLite engine).
+    See <https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.poolclass>
   - **schema**: _(Optional)_ Schema to be applied to a database, if not set in
     config, try to create automatically.
   - **use_threadlocal** <!--??-->

--- a/docs/database.md
+++ b/docs/database.md
@@ -24,6 +24,26 @@ SQLite: `sqlite:////tmp/rucio.db`
 Please ensure correct UNIX permissions on the SQLite file, such that the web
 server process can read and write to it.
 
+## Additional options
+
+### Connection pooling
+
+Connection pooling is enabled by default, but can be disabled by setting the option
+
+```dosini
+poolclass = nullpool
+```
+
+in the `[database]` section in `etc/rucio.cfg`.
+
+Other valid values are `singletonthreadpool`,
+which is the default pooling mechanism when using the SQLite engine,
+and `queuepool`,
+which is the default otherwise.
+
+Note that the chosen `poolclass` may conflict with other pooling options.
+For instance, one cannot combine `poolclass = nullpool` with the `pool_size` option.
+
 ## Upgrading and downgrading the database schema
 
 Rucio uses [Alembic](http://alembic.zzzcomputing.com/en/latest/) as a database


### PR DESCRIPTION
Documents the new `poolclass` option introduced by https://github.com/rucio/rucio/pull/5657 to the `[database]` section in `rucio.cfg`.