### PR TITLE
add webui config options

### DIFF
--- a/docs/configuration_parameters.md
+++ b/docs/configuration_parameters.md
@@ -446,6 +446,8 @@ attributes.
   - **auth_type**: _(Optional)_ Preferred server side config for webui
     authentication. Values: `{oidc, None}`. Default: `None`.
   - **usercert** <!--NOT USED IN CODE-->
+  - **urls**: A CSV specifying urls of Rucio WebUI 2.0 clients. Required for
+    correctly handling pre-flight CORS requests.
 
 ## Rucio configuration table
 


### PR DESCRIPTION
Adds the `urls` option in the `webui` section. This was introduced in https://github.com/rucio/rucio/issues/5843