### PR TITLE
Add code examples to the OpenApi spec file

### DIFF
--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -74,6 +74,9 @@ jobs:
           repository: rucio/rucio
           ref: master
           path: tools/run_in_docker/rucio
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install rucio-api generation dependencies and build markdown sites for the API
         run: |
           python3 -m pip install -U pip setuptools

--- a/tools/build_documentation.sh
+++ b/tools/build_documentation.sh
@@ -15,6 +15,16 @@ DOCS=$SCRIPT_DIR/../docs
 # since the current user does not own the files.
 sudo chown -R "$USER":"$USER" "$AUTO_GENERATED"
 
+echo "Adding code examples to Rest Api Spec file..."
+(
+    cd "$SCRIPT_DIR"/openapi_examples
+    yarn install
+)
+node "$SCRIPT_DIR"/openapi_examples/generate_api_examples.js "$AUTO_GENERATED"/rest_api_doc_spec.yaml > "$AUTO_GENERATED"/rest_api_doc_spec_tmp.yaml
+cp  "$AUTO_GENERATED"/rest_api_doc_spec_tmp.yaml  "$AUTO_GENERATED"/rest_api_doc_spec.yaml
+rm "$AUTO_GENERATED"/rest_api_doc_spec_tmp.yaml
+
+
 echo "Generating Rest Api Docs from Spec File..."
 npx --yes redoc-cli build "$AUTO_GENERATED"/rest_api_doc_spec.yaml --template "$SCRIPT_DIR"/templates/rest_api_html_template.hbs --output "$AUTO_GENERATED"/rest_api_doc.html
 

--- a/tools/openapi_examples/.gitignore
+++ b/tools/openapi_examples/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+yarn.lock
+node_modules

--- a/tools/openapi_examples/generate_api_examples.js
+++ b/tools/openapi_examples/generate_api_examples.js
@@ -1,0 +1,48 @@
+#!/usr/bin/node
+
+// Script to inject code examples into a OpenApi spec file
+// Base taken from https://github.com/Redocly/redoc/issues/15
+
+const openAPISnippet = require('openapi-snippet');
+const yaml = require('js-yaml');
+const fs = require('fs');
+
+const targets = ['shell_curl', 'python_requests', 'node_fetch'];
+
+const addRequestSamples = (swaggerJson) => {
+  const swagger = JSON.parse(JSON.stringify(swaggerJson));
+
+  for (const singlePath in swagger.paths) {
+    Object.keys(swagger.paths[singlePath])
+      .forEach((method) => {
+        try {
+          const snippets = openAPISnippet.getEndpointSnippets(
+            swagger,
+            singlePath,
+            method,
+            targets,
+          );
+
+          if (swagger.paths[singlePath][method]['x-codeSamples'] == null) {
+            swagger.paths[singlePath][method]['x-codeSamples'] = [];
+          }
+
+          snippets.snippets.forEach((snippet) => {
+              swagger.paths[singlePath][method]['x-codeSamples'].push({
+              lang: snippet.title.split(' ')[0],
+              source: decodeURIComponent(snippet.content),
+            });
+          });
+        } catch (error) {
+          console.log(error);
+        }
+      });
+  }
+
+  return swagger;
+};
+
+const args = process.argv.slice(2);
+const openApi = yaml.load(fs.readFileSync(args[0], 'utf8'));
+
+console.log(yaml.dump(addRequestSamples(openApi)));

--- a/tools/openapi_examples/package.json
+++ b/tools/openapi_examples/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "openapi-snippet": "^0.14.0"
+  }
+}


### PR DESCRIPTION
Code examples on how to use the API helps understanding the API and
reduces usage time. Examples can be created easily and the user has an
enhanced user experience.

Code examples are generated from the OpenApi file. They are ingested
into the spec file afterwards.
