### PR TITLE
rewrite transfers documentation

### DIFF
--- a/docs/configuration_parameters.md
+++ b/docs/configuration_parameters.md
@@ -131,11 +131,6 @@ attributes.
     the dogpile system. Default: `600`.
   - **failover_scheme**: Failover schemes. Default: `None`.
   - **filter_transfertool**: _(Optional)_ <!--??--> Default: `None`.
-  - **fts_throttler_cycle**: _(Optional)_ Path to the cycle file (JSON). If not
-    specified cannot perform tuning for this cycle without cycle file. Example:
-    `fts_throttler_cycle.json`. No default.
-  - **fts_throttler_tuning_ratio**: _(Optional)_ Integer. Example: `20`. No
-    default.
   - **ftshosts**: URL of the [File Transfer Service
     (FTS)](https://fts.web.cern.ch/) hosts (separated by commas). Example:
     `https://fts3-pilot.cern.ch:8446, https://fts3-pilot.cern.ch:8446`. <!--NOT
@@ -498,10 +493,6 @@ attributes.
   - **keep_history**: _(Optional)_ Boolean. Default: `False`.
   - **reevaluate_dids_at_close**: _(Optional)_ Flag to reevaluate the DID against
     all the subscriptions when the DID is closed. Boolean. Default: `False`.
-- **throttler**
-  - **mode**: Conveyor-throttler mode. Values: `{DEST_PER_ALL_ACT, DEST_PER_ACT,
-    SRC_PER_ACT, SRC_PER_ALL_ACT}`. Default: `None` for `core/request`,
-    `DEST_PER_ACT` for `rucio-conveyor-throttler`.
 - **transfers**
   - **hop_penalty**: _(Optional)_ Penalty to be applied to each further
     hop. Integer. Default: `10`.

--- a/docs/transfers_overview.md
+++ b/docs/transfers_overview.md
@@ -22,9 +22,13 @@ type) and others.
 The following transfer-related daemons exist in rucio, presented in the order
 they intervene in a transfer lifecycle:
 
-- **preparer**: an optional daemon, but required for some advanced usages, like
-  multiple transfertools together. It is also required to be able to use
-  throttler
+- **preparer**: a strongly recommended optional daemon which is required for 
+  many advanced usages, like multiple transfertools together. 
+  It is also required to be able to use throttler. If active, performs part 
+  of the source selection and path computation work instead of the submitter. 
+  For all new rucio installation, it is recommended to run this daemon and
+  activate it by setting the `conveyor/use_preparer = True` configuration 
+  option.
 - **throttler**: an optional daemon which can throttle request submissions
   to/from an RSE
 - **submitter**, **stager**: perform source selection, path computation and the
@@ -97,11 +101,12 @@ long as it respects the RSE expression. Here, `*` matches any RSE.
 For the seek of the example, lets assume that RSE4 was selected.
 
 The rule evaluation mechanism will then create two transfer requests, which
-will be picked by the transfer machinery. After being processed, if needed,
-by `preparer` and `throttler` the transfers eventually arrive at `submitter`.
+will be picked by the transfer machinery. Depending on the configuration value
+`conveyor/use_preparer`, the transfer will be either handled by the `preparer`
+or by the `submitter` directly. 
 
-At this stage, the submitter finds all the possible sources. It filters out
-the ones which don't match different rule criterias (for example:
+At this stage, the transfer machinery finds all the possible sources. It
+filters out the ones which don't match different rule criterias (for example:
 source RSE expression) and administrative constraints (for example:
 skip blocklisted RSEs). It then computes the paths. In the previous example,
 the path `RSE1 -> RSE2 -> RSE3 -> RSE4` will be picked due to cost constraints.

--- a/docs/transfers_preparer.md
+++ b/docs/transfers_preparer.md
@@ -1,0 +1,84 @@
+---
+id: transfers-preparer
+title: Transfers Preparer
+---
+
+`conveyor-preparer` (transfer preparer) is the main entry point into the
+transfer machinery. It leverages topological information to pick the best source
+replica for the transfer. It also decides if the transfer has to be handled by
+the throttler or not. For all new rucio installations, it is recommended to run
+this daemon and activate it by setting the `conveyor/use_preparer = True`
+configuration option.
+
+Preparer:
+
+- finds all source RSEs which have a replica of the desired file
+- filters out the source RSEs which don't respect administrative constraints
+- ensures protocol compatibility between sources and destination
+- performs path computations to find the best sources
+- transitions the transfer request either to a `Waiting` or to a `Queued` state
+
+# Source replica selection
+
+One of the main jobs done by the preparer is the selection of the replica
+to be used as a transfer sources. For that, it relies on multiple RSE
+attributes and on the configured protocols. This section provides a summary
+of what configuration parameters can influence the preparer at this stage.
+
+We will use the notation `section/option` to speak about a configuration
+value to be set in `rucio.cfg` like this:
+
+```text
+[section]
+option = value
+```
+
+The preparer will start by retrieving all the possible sources from the
+database.
+
+In the following step, the preparer will skip all sources which don't
+respect the administrative constraints. For example, it will ignore source
+RSEs with `availability_read=False` (unless the preparer is run with
+`--ignore-availability`). It also respects the `restricted_read` and
+`restricted_write` RSE attributes for the source and the destination.
+
+Some request attributes will impact the source selection. For example, preparer
+will skip source RSEs which don't match the `source_replica_expression` or
+`allow_tape_source` conditions. It will also ignore requests witch require a
+`transfertool` that this preparer cannot use. The request attributes are
+either inherited from the rule, or set by another transfer daemon
+(for example: preparer)
+
+The next step is to perform the path computation. At this stage, preparer
+uses the distance between RSEs to perform shortest-path computations. If
+multi-hopping is enabled via `transfers/use_multihop`, then the configuration
+value `transfers/hop_penalty` + the RSE attributes `available_for_multihop`
+and `hop_penalty` will influence the distances for multi-hop paths.
+Each hop, even for single-hop transfers, must respect the protocol
+compatibility between the source of the hop and its destination. The
+[SCHEME_MAP](https://github.com/rucio/rucio/blob/1b8ca368523d13fd11bc0b32c14528f2fcec778b/lib/rucio/common/constants.py#L48)
+constant defines the compatibility between protocols. Only protocols with
+non-zero `third_party_copy_read` will be considered for source RSEs, ordered
+by priority. Same for the destination: `third_party_copy_write` is used.
+
+**Note**: distances between RSEs which are set by the administrator via
+
+```shell
+rucio-admin rse add-distance --distance 1 RSE1 RSE2
+```
+
+Once all valid paths are found, after all the filtering done previously,
+the paths are ordered using the following simple
+[rules](https://github.com/rucio/rucio/blob/608c9b1dc834f07396cc49dfcbc3daa613b61d56/lib/rucio/core/transfer.py#L905)
+:
+
+- the source ranking is compared first. Source ranking is an integer which is
+  decreased each time a particular source is found to have an issue to perform
+  this particular transfer. It is thus equal to 0 at first try, and decreased
+  at transfer failure before re-trying the transfer. This ensures that
+  problematic sources are much less likely to be re-used.
+- On equal source ranking, the RSE type is checked. Disk sources are preferred
+  over tape.
+- On equal source RSE type, the distance between the source RSE and the
+  destination RSE is compared.
+- On equal distance, we prefer single-hop paths.

--- a/docs/transfers_submitter.md
+++ b/docs/transfers_submitter.md
@@ -7,91 +7,33 @@ The `conveyor-submitter` (transfer submitter) is the rucio daemon in charge
 of submitting transfers for execution by an external third-party-copy
 trasfertool. As input, it gets the transfer requests in `queued` state and
 performs multiple tasks on them with the end goal of submitting the actual
-transfer to one or more transfertools. It:
+transfer to one or more transfertools.
 
-- finds all source RSEs which have a replica of the desired file
-- filters out the source RSEs which don't respect administrative constraints
-- ensures protocol compatibility between sources and destination
-- performs path computations to find the best sources
+Historically, submitter was the main entry point into the transfer machinery
+instead of the preparer. Because of that, many old rucio installations don't
+run the preparer daemon. To allow running in such configuration, submitter
+automatically detects if preparer is running and, if it's not running, will
+perform the "Source replica selection". See the preparer documentation for more
+details.
+
+The Submitter:
+
+- (if preparer is not running) selects the source replica
+- computes the path for the selected replica
+- checks transfertool-specific RSE attributes
+- creates intermediate hops for multi-hop transfers
 - generates the full URIs to be used by the transfertool
 - performs the actual submission of the transfer
 
-# Source replica selection
+If the configuration value `conveyor/filter_transfertool` is set, submitter
+will only work on transfers having the `transfertool` attribute set to the
+correct value. This database field is filled by the preparer, so preparer is
+required for multi-transfertool deployments.
 
-One of the main jobs done by the submitter is the selection of the replica
-to be used as a transfer sources. For that, it relies on multiple RSE
-attributes and on the configured protocols. This section provides a summary
-of what configuration parameters can influence the submitter at this stage.
-
-We will use the notation `section/option` to speak about a configuration
-value to be set in `rucio.cfg` like this:
-
-```text
-[section]
-option = value
-```
-
-The submitter will start by retrieving all the possible sources from the
-database. If the configuration value `conveyor/filter_transfertool` is set, it
-will avoid source RSEs which don't have the `transfertool` RSE attribute
-set to the correct value. Except for a particular case: when submitter is
-run with a list of transfertools in `conveyor/transfertool` and multi-hoping
-is enabled. In this case the `transfertool` RSE attribute will be ignored at
-this stage, because we assume a will to multi-hop between transfertools.
-
-In the following step, the submitter will skip all sources which don't
-respect the administrative constraints. For example, it will ignore source
-RSEs with `availability_read=False` (unless the submitter is run with
-`--ignore-availability`). It also respects the `restricted_read` and
-`restricted_write` RSE attributes for the source and the destination.
-
-Some request attributes will impact the source selection. For example, submitter
-will skip source RSEs which don't match the `source_replica_expression` or
-`allow_tape_source` conditions. It will also ignore requests witch require a
-`transfertool` that this submitter cannot use. The request attributes are
-either inherited from the rule, or set by another transfer daemon
-(for example: preparer)
-
-The next step is to perform the path computation. At this stage, submitter
-uses the distance between RSEs to perform shortest-path computations. If
-multi-hopping is enabled via `transfers/use_multihop`, then the configuration
-value `transfers/hop_penalty` + the RSE attributes `available_for_multihop`
-and `hop_penalty` will influence the distances for multi-hop paths.
-Each hop, even for single-hop transfers, must respect the protocol
-compatibility between the source of the hop and its destination. The
-[SCHEME_MAP](https://github.com/rucio/rucio/blob/1b8ca368523d13fd11bc0b32c14528f2fcec778b/lib/rucio/common/constants.py#L48)
-constant defines the compatibility between protocols. Only protocols with
-non-zero `third_party_copy_read` will be considered for source RSEs, ordered
-by priority. Same for the destination: `third_party_copy_write` is used.
-
-**Note**: distances between RSEs which are set by the administrator via
-
-```shell
-rucio-admin rse add-distance --distance 1 --ranking 1 RSE1 RSE2
-```
-
-Once all valid paths are found, after all the filtering done previously,
-the paths are ordered using the following simple
-[rules](https://github.com/rucio/rucio/blob/608c9b1dc834f07396cc49dfcbc3daa613b61d56/lib/rucio/core/transfer.py#L905)
-:
-
-- the source ranking is compared first. Source ranking is an integer which is
-  decreased each time a particular source is found to have an issue to perform
-  this particular transfer. It is thus equal to 0 at first try, and decreased
-  at transfer failure before re-trying the transfer. This ensures that
-  problematic sources are much less likely to be re-used.
-- On equal source ranking, the RSE type is checked. Disk sources are preferred
-  over tape.
-- On equal source RSE type, the distance between the source RSE and the
-  destination RSE is compared.
-- On equal distance, we prefer single-hop paths.
-
-In its final step before submission, submitter will check in order the
-paths from the previous steps until it finds one which can be submitted by
-any of the transfertools configured in `conveyor/transfertool`. Here
-transfertool-specific RSE attributes enter into the equation. For example,
-the fts3 transfertool requires an `fts` RSE attribute with a list of fts
-servers; while the globus transfertool requires the `globus_endpoint_id`
+To verify if a path cen be submitted by any of the transfertools configured
+in `conveyor/transfertool`, transfertool-specific RSE attributes are used. For
+example, the fts3 transfertool requires an `fts` RSE attribute with a list of
+fts servers; while the globus transfertool requires the `globus_endpoint_id`
 attribute on both source and destination RSE.
 
 If a path can be submitted, all missing hops are created into the database,

--- a/docs/transfers_throttler.md
+++ b/docs/transfers_throttler.md
@@ -1,0 +1,40 @@
+---
+id: transfers-throttler
+title: Transfers Throttler
+---
+
+As the name suggests, `conveyor-throttler` (transfer throttler) is used to
+protect the transfertools from overload by limiting the number of submitter
+transfers at any particular moment of time. 
+
+Preparer is required to be able to run throttler. See the preparer documentation
+on how to activate it.
+
+The rucio administrator must manually configure throttling rules.  As of time
+of writing, there is no CLI option in rucio-admin to do it. Rules have to be
+added using the rucio core functions directly from a rucio node.
+
+**Warning**: only set transfer limits if throttler is running. Otherwise,
+preparer will transition transfers to the `waiting` state, but nobody will
+consume the queue of waiting transfers. Leading to these transfers never
+being executed.
+
+```python
+from rucio.core.request import set_transfer_limit, list_transfer_limits
+
+list(list_transfer_limits())
+set_transfer_limit("RSE1", max_transfers=100)
+```
+
+The previous code snippet will create (or update) the 'destination' throttling
+rule for transfers towards RSE1. A maximum of 100 transfers will be allowed
+at a time towards RSE1. Note that "RSE1" here is an RSE expression, not
+a name, complex RSE expressions can be used in rules. If more than one rule
+applies to a specific RSE, the more restrictive condition applies.
+
+Throttler supports some advanced throttler techniques. Some of them are:
+- source throttling
+- grouping of files from the same dataset together (grouped_fifo strategy)  
+
+These techniques can be costly on the database and were not extensively tested.
+The only technique we use in production is destination throttling.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -50,6 +50,8 @@
                 {
                     "Transfers": [
                         "transfers-overview",
+                        "transfers-preparer",
+                        "transfers-throttler",
                         "transfers-submitter",
                         "configure-rucio-globus"
                     ]


### PR DESCRIPTION
- insist on preparer being highly recommended
- re-organize preparer and submitter to include changes from 1.29 and 1.30
- add a basic throttler documentation