### PR TITLE
Moving "Developing with Rucio" to User section #25

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -38,7 +38,8 @@
                             "dirName": "client_api"
                         }
                     ]
-                }
+                },
+                "developing_with_rucio"
             ],
             "Operator": [
                 "installing_server",
@@ -69,7 +70,6 @@
             ],
             "Developer": [
                 "setting_up_demo",
-                "developing_with_rucio",
                 "contributing",
                 "rest_api_doc",
                 "component_leads",


### PR DESCRIPTION
As discussed previous with @bari12, the suggested solution is to move _"Developing with Rucio"_ from **Developer** to **User** menu section.