### PR TITLE
mention the difference of --distance vs --ranking pre 1.30. Closes #199

### DIFF
--- a/docs/rucio_storage_element.md
+++ b/docs/rucio_storage_element.md
@@ -34,11 +34,7 @@ transfer requests can be made to Rucio in order to populate the cache.
 
 ## Distances between RSEs
 
-When configuring transfers between RSEs, bidirectional distances or rankings
-must be defined for that link. When sorting by these distances in the selection
-of a transfer source, the following criterion are used:
-
-- Higher source_ranking first
-- On equal source_ranking, prefer DISK over TAPE
-- On equal type, prefer lower distance_ranking
-- On equal distance, prefer single hop
+When configuring transfers between RSEs, distances must be defined for that link.
+Distances are unidirectional. To allow transfers in both directions, a distance
+has to be defined separately in each direction. Refer to the section
+[Transfers Overview](transfers_overview.md) for more details.

--- a/docs/transfers_preparer.md
+++ b/docs/transfers_preparer.md
@@ -65,6 +65,12 @@ by priority. Same for the destination: `third_party_copy_write` is used.
 
 ```shell
 rucio-admin rse add-distance --distance 1 RSE1 RSE2
+# Note: before rucio 1.30 (as a consequence: also in the current LTS release 1.29),
+# the --ranking option was used for the same purpose. The --distance option
+# could still be set and was mentioned in documentation alongside --ranking
+# but was completely ignored by rucio.
+# On 1.29, you'll have to use the following command:
+rucio-admin rse add-distance --ranking 1 RSE1 RSE2
 ```
 
 Once all valid paths are found, after all the filtering done previously,


### PR DESCRIPTION
1.29 is still the current LTS release and will be used by many communities for a long time.