### PR TITLE
Update Rucio Image Tag (Hardcoded)

### DIFF
--- a/tools/generate_dynamic_files.sh
+++ b/tools/generate_dynamic_files.sh
@@ -5,5 +5,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 docker run --rm \
        --volume "$SCRIPT_DIR/run_in_docker:/run_in_docker:rw" \
        --volume "$SCRIPT_DIR/auto_generated:/auto_generated:rw" \
-       ghcr.io/rucio/rucio/rucio-autotest:fedora32-python3.8 \
+       ghcr.io/rucio/rucio/rucio-autotest:alma9-python3.9 \
        /bin/bash -c /run_in_docker/generate_docs.sh


### PR DESCRIPTION
Change the downloaded rucio image from `fedora32-python3.8` to `alma9-python3.9` because the former was outdated and caused errors in the docs build process.

Note that this hardcodes the image tag and the tag needs to be changed each time rucio is updated to reflect changes made there.

A "better" solution would be to query the "latest" tag, but this does not exist on the github container repository (GHCR), to the best of my knowledge.