### PR TITLE
Tools: Update `generate_release_notes_index.py` to new versioning scheme

### DIFF
--- a/tools/generate_release_notes_index.py
+++ b/tools/generate_release_notes_index.py
@@ -40,57 +40,67 @@ def map_post_version_sort_to_number(stem: str) -> int:
     return 1
 
 
-def render_templates(templates_dir: str, output_path: pathlib.Path) -> None:
-    def minor_release_get_title(path: str, version: str) -> str:
-        """
-        Returns the title for a minor release. If this title does not exist it
-        returns the version string itself.
+def minor_release_get_title(path: str, version: str) -> str:
+    """
+    Returns the title for a minor release. If this title does not exist it
+    returns the version string itself.
 
-        :param path: The path to the folder containing the release informations.
-        :param version: A major and minor version of a release. (e.g. "1.27")
-        :returns: The coresponsing release title. This is just the version string in
-            case no title exist.
-        """
-        # We hardcode the minor release titles for now, since there is no easy
-        # way to automatically get them.
-        HARD_CODED_RELEASE_NOTE_TITLE = {
-            "33.0": "Eternal Sunshine of the Donkey's Mind",
-            "32.0": "The Good, The Bad and the Donkey",
-            "1.31": "Donkeys of the Caribbean",
-            "1.30": "The Donkeynator",
-            "1.29": "Into the Donkeyverse",
-            "1.28": "Teenage Mutant Ninja Donkeys",
-            "1.27": "Batdonkey v Superdonkey",
-            "1.26": "Donkey League of La Mancha",
-            "1.25": "Rat-Donkey",
-            "1.24": "Aquadonkey",
-            "1.23": "The incredible Donkey",
-            "1.22": "Green Donkey",
-            "1.21": "Donkeys of the Galaxy",
-            "1.20": "Wonder Donkey",
-            "1.19": "Fantastic Donkeys",
-            "1.18": "Invisible Donkey",
-            "1.17": "Donkey Surfer",
-            "1.16": "Doctor Donkey",
-            "1.15": "Daredonkey",
-            "1.14": "Professor D",
-            "1.13": "Donkerine",
-            "1.12": "Captain Donkey",
-            "1.11": "Batdonkey",
-            "1.10": "Irondonkey",
-            "1.9": "Superdonkey",
-            "1.8": "Spiderdonkey",
-            "1.7": "Donkey One",
-            "1.6": "The Donkey awakens",
-            "1.5": "Return of the Donkey",
-            "1.4": "The Donkey strikes back",
-        }
-        if version in HARD_CODED_RELEASE_NOTE_TITLE:
+    :param path: The path to the folder containing the release informations.
+    :param version: A major and minor version of a release. (e.g. "1.27")
+    :returns: The coresponsing release title. This is just the version string in
+        case no title exist.
+
+    Note that due to the switch to a new versioning scheme between version
+    1.31 and 32, we need to handle version strings beginning with "1."
+    differently.
+    """
+    # We hardcode the minor release titles for now, since there is no easy
+    # way to automatically get them.
+    HARD_CODED_RELEASE_NOTE_TITLE = {
+        "33": "Eternal Sunshine of the Donkey's Mind",
+        "32": "The Good, The Bad and the Donkey",
+        "1.31": "Donkeys of the Caribbean",
+        "1.30": "The Donkeynator",
+        "1.29": "Into the Donkeyverse",
+        "1.28": "Teenage Mutant Ninja Donkeys",
+        "1.27": "Batdonkey v Superdonkey",
+        "1.26": "Donkey League of La Mancha",
+        "1.25": "Rat-Donkey",
+        "1.24": "Aquadonkey",
+        "1.23": "The incredible Donkey",
+        "1.22": "Green Donkey",
+        "1.21": "Donkeys of the Galaxy",
+        "1.20": "Wonder Donkey",
+        "1.19": "Fantastic Donkeys",
+        "1.18": "Invisible Donkey",
+        "1.17": "Donkey Surfer",
+        "1.16": "Doctor Donkey",
+        "1.15": "Daredonkey",
+        "1.14": "Professor D",
+        "1.13": "Donkerine",
+        "1.12": "Captain Donkey",
+        "1.11": "Batdonkey",
+        "1.10": "Irondonkey",
+        "1.9": "Superdonkey",
+        "1.8": "Spiderdonkey",
+        "1.7": "Donkey One",
+        "1.6": "The Donkey awakens",
+        "1.5": "Return of the Donkey",
+        "1.4": "The Donkey strikes back",
+    }
+    try:
+        if version[:2] == "1.":
             return version + " " + HARD_CODED_RELEASE_NOTE_TITLE[version]
+        else:
+            return f"{version} {HARD_CODED_RELEASE_NOTE_TITLE[version.split('.')[0]]}"
+    except KeyError:
         raise Exception(
-            f"The minor version {version} is not present in the hardcoded list of minor release titles!"  # noqa: E501
+            f"Version {version} is not present in the hardcoded"
+            "list of minor release titles!"
         )
 
+
+def render_templates(templates_dir: str, output_path: pathlib.Path) -> None:
     def index_item(path: pathlib.Path) -> dict:
         return {"stem": path.stem, "path": str(path.relative_to(output_path))}
 

--- a/tools/run_in_docker/rucio_processor.py
+++ b/tools/run_in_docker/rucio_processor.py
@@ -39,7 +39,7 @@ def sanitize(s: t.Optional[str]) -> str:
         r">": r"\>",
     }
 
-    for (before, after) in character_map.items():
+    for before, after in character_map.items():
         s = s.replace(before, after)
     return s
 
@@ -83,7 +83,6 @@ def generate_sections_markdown(sections):
 
 @dataclasses.dataclass
 class RucioProcessor(Processor):
-
     _KEYWORDS = {
         "Arguments": [
             "arg",

--- a/tools/run_in_docker/rucio_renderer.py
+++ b/tools/run_in_docker/rucio_renderer.py
@@ -39,7 +39,6 @@ def sanitize(s: str) -> str:
 
 @dataclasses.dataclass
 class RucioRenderer(Renderer):
-
     markdown: MarkdownRenderer = dataclasses.field(default_factory=MarkdownRenderer)
 
     def init(self, context: Context) -> None:


### PR DESCRIPTION
We need to handle versions beginning with `"1."` differently from others. This is because we switched to the new scheme between version 1.31 and version 32.