### PR TITLE
Docs: Release-Note Generation overhaul

### DIFF
--- a/tools/.flake8
+++ b/tools/.flake8
@@ -3,7 +3,5 @@ exclude =
     .git,
     __pycache__,
     rucio
-max-complexity = 10
-
-# This is the default value balck uses
-max-line-length = 88
+max-line-length=256
+ignore=E731,E722,W503

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 import os
 import re
 from dataclasses import dataclass

--- a/tools/templates/release-notes.md.j2
+++ b/tools/templates/release-notes.md.j2
@@ -3,18 +3,13 @@ title: Release Notes
 sidebar_label: Release Notes
 ---
 
-Below listed are all the release notes from the very first release
-uptil the latest one:
+We list the release notes in reverse chronological order, with the newest
+release first.
 
-{% for group, items in index("release-notes") | dictsort(reverse = True) %}
-## {{ minor_release_get_title("release-notes", group) }}
+{% for key, value in index().items()  %}
 
-{% for item in items
-  | sort(
-    reverse = True,
-    attribute = "major_version_number,minor_version_number,patch_version_number,post_version_sort,stem"
-  ) -%}
-- [{{ item['stem'] }}]({{item['path']}})
+## {{ get_release_title(key) }}
+{% for version in value -%}
+- [{{version}}]({{get_release_link(version)}})
 {% endfor -%}
-
 {% endfor %}


### PR DESCRIPTION
the introduction of semantic versioning with version 32 brought new challenges in the parsing, sorting and grouping the version names for the release notes. Added the necessary functionality to the `generate_release_notes.py` script, effectively rewriting it. The intent was the following:

* Handle both the old and new style of semantic versioning
* Simplify the code in the jinja template `release-notes.md.j2`
* Remove code from the python script that made it too general, sharpened it for its intended purpose.