### PR TITLE
Remove Docker Compose from list of extensions in VSCode setup doc

### DIFF
--- a/docs/developer/setting_up_vscode_dev_env.md
+++ b/docs/developer/setting_up_vscode_dev_env.md
@@ -88,7 +88,6 @@ Install the following extensions:
 - [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
 - [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
 - [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-- [Docker Compose](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
 
 VSCode comes with a plethora of extensions that can significantly improve your development experience. For more information, see [Extensions](https://code.visualstudio.com/docs/editor/extension-gallery)
 


### PR DESCRIPTION
Under the list of VSCode extensions, the Docker extension is linked to twice, first as "Docker" and then as "Docker Compose". 

The Docker extension adds functionality for Docker Compose as well (https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker), so there's no Compose-specific extension needed in any case - removing it from the list