### PR TITLE
Correct capitalization of API and add oidc.py to files to ignore for type annotation

### DIFF
--- a/docs/developer/rest_api_doc.md
+++ b/docs/developer/rest_api_doc.md
@@ -1,35 +1,35 @@
 ---
 title: REST API Documentation
 ---
-Rucio provides a Rest Api interface for client-server communication. The code
+Rucio provides a Rest API interface for client-server communication. The code
 for the server is located in the Rucio project under `lib/rucio/rest/flask/v1`.
 
-The Rest Api Documentation provides a sufficient documentation of all endpoints
+The Rest API Documentation provides a sufficient documentation of all endpoints
 and should be descriptive enough so that it is not required to look at the code
 anymore.
 
 ## Tools
 
-The main framework for the Rest Api Documentation is **OpenApi**. ApiSpec
-extracts the OpenApi specification conform method documentation strings from the
-Flask Api and constructs the overall OpenApi specification file. This
+The main framework for the Rest API Documentation is **OpenAPI**. APISpec
+extracts the OpenAPI specification conform method documentation strings from the
+Flask API and constructs the overall OpenAPI specification file. This
 specification file contains all endpoints and their parameter and return value
 documentation.
 
-### ApiSpec
+### APISpec
 
-`ApiSpec` is a python framework to extract Python doc comments and generate a
-valid OpenApi spec file from it. The documentation for each endpoint is a
+`APISpec` is a python framework to extract Python doc comments and generate a
+valid OpenAPI spec file from it. The documentation for each endpoint is a
 yaml-conform python method doc string starting after `---`. The
 `apispec_webframeworks.flask` library connects the Python doc comments with the
 endpoints given by Flask.
 
-`tools/generate_rest_api_doc.py` generates the OpenApi specification file with
-ApiSpec.
+`tools/generate_rest_api_doc.py` generates the OpenAPI specification file with
+APISpec.
 
 :::note
 
-The latest OpenApi specification for the Rest Api Documentation is available
+The latest OpenAPI specification for the Rest API Documentation is available
 [here](pathname:///yaml/rest_api_doc_spec.yaml).
 
 :::
@@ -47,7 +47,7 @@ several advantages over other front-end tools:
 :::note
 
 Front-end generators only need the spec file and some configuration to generate
-a user friendly view of the documentation. Select a generator from the [OpenApi
+a user friendly view of the documentation. Select a generator from the [OpenAPI
 Tools](https://openapi.tools/#documentation) and generate your own front-end.
 
 :::
@@ -87,15 +87,15 @@ The doc changes are tightly coupled with the code. Making a lot of changes to
 the code and then one commit with all the documentation changes leads to a
 divergent history (What if the code commits get reverted?).
 
-### Skim the [OpenApi](https://swagger.io/specification/) definition
+### Skim the [OpenAPI](https://swagger.io/specification/) definition
 
-OpenApi is feature rich and may have some easier/standardized way to express
+OpenAPI is feature rich and may have some easier/standardized way to express
 what you think. E.g. deprecated fields can be marked with `deprecated: true`.
 Knowing the framework and library you're working with is always a good idea. ;-)
 
-### [OpenApi Tools](https://openapi.tools/)
+### [OpenAPI Tools](https://openapi.tools/)
 
-The OpenApi Tools are a collection of tools to support writing, verifying and
-displaying Rest Api Documentations. They also provide some ideas on how to
+The OpenAPI Tools are a collection of tools to support writing, verifying and
+displaying Rest API Documentations. They also provide some ideas on how to
 further integrate the documentation into other parts of your code base, e.g. for
 input validation.

--- a/docs/developer/type_annotation_guide.md
+++ b/docs/developer/type_annotation_guide.md
@@ -117,6 +117,10 @@ The following modules will **not** be type annotated:
     - The db module is used as a dependency of core. While we need the types, we
       use very little functions out of it. We might activate support later,
       however we want to focus on core right now.
+- `lib/rucio/core/oidc.py`
+    - `pyjwkest` is no longer maintained and needs to be replaced,
+      and some functions are planned to be removed in the future.
+      It is best to skip this file for now.
 
 ### Dependencies
 


### PR DESCRIPTION
On API capitalization:
- REST API: https://www.redhat.com/en/topics/api/what-is-a-rest-api (not the main REST API reference, but a good enough source)
- OpenAPI: https://swagger.io/specification/
- Flask API: https://flask.palletsprojects.com/en/latest/api/
- APISpec: this one is interchangeably written as either `apispec` or `APISpec` (e.g. here: https://apispec.readthedocs.io/en/latest/special_topics.html) - I think APISpec is more consistent with the other API naming conventions