### PR TITLE
Fix broken link to client API

### DIFF
--- a/docs/user/developing_with_rucio.md
+++ b/docs/user/developing_with_rucio.md
@@ -18,7 +18,7 @@ rucio_client.ping()
 ```
 
 The methods are separated per resource type. The API in full can be viewed
-[here](client_api/accountclient).
+[here](/client_api/accountclient).
 
 ### Errors and Exceptions
 


### PR DESCRIPTION
The link in https://rucio.github.io/documentation/user/developing_with_rucio is relative at the moment, so it can't find the correct page, and links to https://rucio.github.io/documentation/user/client_api/accountclient

Fixing it to correctly link to the client API page (tested locally)