### PR TITLE
Remove brackets in config example for did meta

### DIFF
--- a/docs/operator/did_meta.md
+++ b/docs/operator/did_meta.md
@@ -95,6 +95,6 @@ Configuration options for Metadata are::
 
 ```python
 [metadata]
-# plugins = [list_of_plugins,comma_separated]
-plugins = [rucio.core.did_meta_plugins.did_column_meta.DidColumnMeta, escape.rucio.did_meta_plugin]
+# plugins = list_of_plugins,comma_separated
+plugins = rucio.core.did_meta_plugins.did_column_meta.DidColumnMeta,escape.rucio.did_meta_plugin
 ```


### PR DESCRIPTION
Trying to setup the mongo metadata server, I got the following error when trying to setup it in the way described in the documentation:

> ModuleNotFoundError: No module named '[rucio'

Leaving out the brackets seems to work, at least for a single plugin