### PR TITLE
Remove extraneous punctuation

### DIFF
--- a/docs/operator/did_meta.md
+++ b/docs/operator/did_meta.md
@@ -91,7 +91,7 @@ against a particular regex while other might accept all possible keys.
 
 ## How to configure which metadata plugin to use
 
-Configuration options for Metadata are::
+Configuration options for Metadata are:
 
 ```python
 [metadata]

--- a/docs/user/using_the_admin_client.md
+++ b/docs/user/using_the_admin_client.md
@@ -9,7 +9,7 @@ by any user, but the set methods require some admin privileges. See the
 
 ## Account and identity methods
 
-To create a new account::
+To create a new account:
 
 ```bash
   $ rucio-admin account add --type USER --email jdoe@blahblih.com jdoe
@@ -17,7 +17,7 @@ To create a new account::
 
 You can choose different types in the list USER, GROUP, SERVICE. Different
 policies/permissions can be set depending on the account type.  Once the account
-is created, you need to create and attach an identity to this account::
+is created, you need to create and attach an identity to this account:
 
 ```bash
   $ rucio-admin identity add --type X509 \
@@ -25,20 +25,20 @@ is created, you need to create and attach an identity to this account::
       --email jdoe@blahblih.com --account jdoe
 ```
 
-The list of possible identity types is X509, GSS, USERPASS, SSH::
+The list of possible identity types is X509, GSS, USERPASS, SSH:
 
 ```bash
   $ rucio-admin account list-identities jdoe
   Identity: CN=jdoe,OU=Users,OU=Organic Units,DC=blih,DC=blah,        type: X509
 ```
 
-You can set attributes to the users::
+You can set attributes to the users:
 
 ```bash
   $ rucio-admin account add-attribute --key country --value xyz jdoe
 ```
 
-And list these attributes::
+And list these attributes:
 
 ```bash
   $ rucio-admin account list-attributes jdoe
@@ -50,14 +50,14 @@ And list these attributes::
 ```
 
 You can also list all the accounts matching a certain attribute using the filter
-option::
+option:
 
 ```bash
   $ rucio-admin account list --filters "country=xyz"
   jdoe
 ```
 
-To set the quota for one account on a given RSE::
+To set the quota for one account on a given RSE:
 
 ```bash
   $ rucio-admin account set-limits jdoe SITE2_SCRATCH 10000000000000
@@ -68,7 +68,7 @@ To set the quota for one account on a given RSE::
 
 ## Scope methods
 
-To create a new scope::
+To create a new scope:
 
 ```bash
   $ rucio-admin scope add --account jdoe --scope user.jdoe
@@ -76,7 +76,7 @@ To create a new scope::
 
 Only the owner of the scope or privileged users can write into the scope.
 
-To list all the scopes::
+To list all the scopes:
 
 ```bash
   $ rucio-admin scope list
@@ -86,19 +86,19 @@ To list all the scopes::
 
 ## RSE methods
 
-To create a new RSE::
+To create a new RSE:
 
 ```bash
   $ rucio-admin rse add SITE2_SCRATCH
 ```
 
-To add a RSE attribute::
+To add a RSE attribute:
 
 ```bash
   $ rucio-admin rse set-attribute --rse SITE2_SCRATCH --key country --value xyz
 ```
 
-To check an RSE attribute::
+To check an RSE attribute:
 
 ```bash
   $ rucio-admin rse get-attribute SITE2_SCRATCH
@@ -107,7 +107,7 @@ To check an RSE attribute::
 
 ## Replica methods
 
-To declare bad (i.e. corrupted or lost replicas)::
+To declare bad (i.e. corrupted or lost replicas):
 
 ```bash
   $ rucio-admin replicas declare-bad --reason "File corrupted" https//path/to/lost/file


### PR DESCRIPTION
Changing `::` to single `:` in normal text