### PR TITLE
Fix known broken links, up the retry count and time for 429s

### DIFF
--- a/docs/developer/webui/streamedtables.md
+++ b/docs/developer/webui/streamedtables.md
@@ -34,7 +34,7 @@ of the `ComDOM`.
 
 The generic component when dealing with streamed data is the `StreamedTable`,
 which is a custom HTML table framework based on [Tanstack
-Table](https://tanstack.com/table/v8/docs/guide/introduction) and optimised for
+Table](https://tanstack.com/table/v8/docs/introduction) and optimized for
 use with the streams fed in via the ComDOM. A StreamedTable is defined by a set
 of react props passed into the component (which will be described below). The
 framework is completed by a plethora of ready-to-use components which solve the

--- a/docs/operator/kubernetes.md
+++ b/docs/operator/kubernetes.md
@@ -60,7 +60,7 @@ that have to be done. These can be done on the `rucio-server` pod of the cluster
 are performed with the [Alembic](http://alembic.zzzcomputing.com/en/latest/) tool.
 
 The alembic.ini template can be found
-[here](https://github.com/rucio/rucio/blob/master/alembic.ini.template).
+[here](https://github.com/rucio/rucio/blob/master/etc/alembic.ini.template).
 A kubernetes+postgresql specific version can be found in the KM3NeT example
 [here](https://git.km3net.de/rucio/rucio-deployment/-/blob/main/docs/alembic.ini).
 Fill in the correct values before transferring the file to the `rucio-server` pod:

--- a/tools/link-check.json
+++ b/tools/link-check.json
@@ -10,7 +10,8 @@
 	    "pattern": "https?://ip:"
 	}
     ],
-    "retryOn429": true,
-    "fallbackRetryDelay": 1,
+	"retryOn429": true,
+	"fallbackRetryDelay": "2m",
+	"retryCount": 3,
     "aliveStatusCodes": [200, 403]
 }


### PR DESCRIPTION
Like it says on the tin. Updated dead links, up'd the retry timer for 429's.

Currently will still fail because daxiv's documentation seems to be having some problems. ([This page is down, but in the right place](https://davix.web.cern.ch/davix/docs/devel/cloud-support.html#amazon-s3))