### PR TITLE
Clarify patch release schedule

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,7 +19,7 @@ development mailing list [__rucio-dev@cern.ch__](mailto:rucio-dev@cern.ch).
 A contribution can be either be a **patch** or **feature**:
 
 * **Patches** include bugfixes and minor changes to the code and are included in
-  patch releases usually made on a bi-weekly schedule.
+  patches that are usually relased every two weeks.
 * **Features** include major developments or potentially disruptive changes and
   are included in feature releases made multiple times a year.
 

--- a/docs/started/releasepolicy.md
+++ b/docs/started/releasepolicy.md
@@ -8,8 +8,9 @@ Rucio follows a release policy, based on [semantic versioning](https://semver.or
 with **major** (named) releases. Approximately
 every 4 months we produce a major release with a version number like **x.0.0**
 (with x > 0). A major release marks the start of a release line. This release
-line is maintained with bi-weekly minor/patch releases, containing bug fixes or minor
-enhancements, with version numbers like **32.y.z** (with y &ge; 0, z &ge; 0). Versions within
+line is maintained with minor/patch releases published every two weeks,
+containing bug fixes or minor enhancements,
+with version numbers like **32.y.z** (with y &ge; 0, z &ge; 0). Versions within
 one release line are always backwards compatible, thus they do not include
 database schema changes, API modifications, or other backward-compatibility
 breaking changes.


### PR DESCRIPTION
"Biweekly" can unfortunately mean either twice a week or once every two weeks: https://en.wiktionary.org/wiki/biweekly#English

To clarify, "biweekly" is changed to "once every two weeks"