### PR TITLE
Remove KM3NeT broken link example; fix #340

### DIFF
--- a/docs/operator/kubernetes.md
+++ b/docs/operator/kubernetes.md
@@ -61,8 +61,6 @@ are performed with the [Alembic](http://alembic.zzzcomputing.com/en/latest/) too
 
 The alembic.ini template can be found
 [here](https://github.com/rucio/rucio/blob/master/etc/alembic.ini.template).
-A kubernetes+postgresql specific version can be found in the KM3NeT example
-[here](https://git.km3net.de/rucio/rucio-deployment/-/blob/main/docs/alembic.ini).
 Fill in the correct values before transferring the file to the `rucio-server` pod:
 
 ```


### PR DESCRIPTION
This link used to point to `alembic.ini` in https://git.km3net.de/rucio/rucio-deployment/-/tree/main, but this file has been removed.

This is their documentation on database migration: https://rucio.pages.km3net.de/rucio-documentation/installation/#updating-an-existing-database-to-a-newer-version-of-rucio, which just points to the Rucio documentation and does not mention the specific k8s+Postgres case that we were originally pointing to their file for.

I think it's worth just removing this link, rather than e.g. pointing to an outdated version of `alembic.ini` in the git history for their repo