### PR TITLE
Stop removing non-existant gitignore

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -23,12 +23,6 @@ mv output.git "${OUTPUT_DIRECTORY}/.git"
 cd "${OUTPUT_DIRECTORY}"
 touch .nojekyll
 
-# We want to add the assets to the deployment, however we don't want to have the
-# changes in the versioning system. Deleting the .gitignore files will add the
-# assets to the deployment.
-rm html/.gitignore
-rm yaml/.gitignore
-
 git config --local user.email "action@github.com"
 git config --local user.name "GitHub Action"
 git add .


### PR DESCRIPTION
Should stop the action errors. Not sure why the .gitignore files are no longer in the gh-pages branch, but 🤷 