### PR TITLE
Change path for generated python client docs

### DIFF
--- a/tools/run_in_docker/mkdocs.yml
+++ b/tools/run_in_docker/mkdocs.yml
@@ -38,6 +38,7 @@ plugins:
     default_handler: python
     handlers:
       python:
+        paths: [/run_in_docker/rucio/lib]
         options:
           members_order: "source"
           heading_level: 2


### PR DESCRIPTION
Closes #414 

Changing the `paths` variable appends the given source path during documentation generation [(according to the mkdocstrings documentation)](https://mkdocstrings.github.io/python/usage/#using-the-paths-option)

Verified by this worked by adding an annoying little comment in the local rucio clone 

```
...
class AccountClient(BaseClient):

    """Account client class for working with rucio accounts
    
    I am being annoying and testing some changes just by messing around here. 
    """

    ACCOUNTS_BASEURL = 'accounts'
...
```

And verifying it shows up in the generated docs 

![image](https://github.com/user-attachments/assets/b76486fa-f59c-4713-ba01-4292ded76900)
