### PR TITLE
Fix permission reference in config

### DIFF
--- a/docs/operator/configuration_parameters.md
+++ b/docs/operator/configuration_parameters.md
@@ -341,7 +341,7 @@ Rucio will look for the config in the following locations -
     LFN2PFN translation for this server. Default: `hash`.
   - **package**
   - **package-*VO***
-  - **permission**: Same as `policy/permission`.
+  - **permission**: Same as `permission/policy`.
   - **schema**
   - **scratchdisk_lifetime**: _(Optional)_ Integer. Default: `14`.
   - **support**: _(Optional)_ Contact information.


### PR DESCRIPTION
Initially addressed in 6903fd183a0d29fb58fb23214be97ae313af9529, but accidentally added back in 80a67a9d00eb1253febea0cd85474982503c42d3.