### PR TITLE
Correct name in PyClient doc generation

### DIFF
--- a/tools/run_in_docker/generate_client_api_docs.sh
+++ b/tools/run_in_docker/generate_client_api_docs.sh
@@ -11,6 +11,6 @@ pip install --upgrade mkdocs mkdocs-gen-files mkdocstrings-python mkdocs-materia
 mkdir -p /auto_generated/client_api
 
 python3 generate_client_api_pages.py
-mkdocs build --clean --no-directory-urls --config-file mkdocs.yml --site-dir api_site
+mkdocs build --clean --no-directory-urls --config-file mkdocs.yml --site-dir client_api
 
-cp -r api_site /auto_generated/
+cp -r client_api /auto_generated/


### PR DESCRIPTION
Should bring back the client autodoc - broken link introduced in #471 and brought up by @haozturk (Thanks for noticing!!)