### PR TITLE
Revert trailing slash change

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,7 +2,6 @@ module.exports={
   "title": "Rucio Documentation",
   "url": "https://rucio.github.io",
   "baseUrl": "/documentation",
-  "trailingSlash": false,
   "organizationName": "rucio",
   "projectName": "documentation",
   "scripts": [


### PR DESCRIPTION
The trailing slash removal causes pages to break when refreshed or directly linked to - any hyperlinks in md pages need to work around this. 