### PR TITLE
Remove references to deprecated use_multihop option

### DIFF
--- a/docs/operator/configuration_parameters.md
+++ b/docs/operator/configuration_parameters.md
@@ -474,7 +474,6 @@ a setting already specified in the Configuration File.
   - **hop_penalty**: _(Optional)_ Penalty to be applied to each further
     hop. Integer. Default: `10`.
   - **multihop_tombstone_delay**: Seconds (integer). Default: `7200`.
-  - **use_multihop**: Boolean. Default: `False`.
   - **fts3tape_metadata_plugins**: _(Optional)_ Plugins to use with FTS3 to include archive
   metadata in the transfer process. List[String]. Default: `None`.
   - **metadata_byte_limit**: _(Optional)_ Limit applied to `archive_metadata` during a transfer.

--- a/docs/operator/transfers/transfers_preparer.md
+++ b/docs/operator/transfers/transfers_preparer.md
@@ -50,10 +50,7 @@ either inherited from the rule, or set by another transfer daemon
 (for example: preparer)
 
 The next step is to perform the path computation. At this stage, preparer
-uses the distance between RSEs to perform shortest-path computations. If
-multi-hopping is enabled via `transfers/use_multihop`, then the configuration
-value `transfers/hop_penalty` + the RSE attributes `available_for_multihop`
-and `hop_penalty` will influence the distances for multi-hop paths.
+uses the distance between RSEs to perform shortest-path computations.
 Each hop, even for single-hop transfers, must respect the protocol
 compatibility between the source of the hop and its destination. The
 [SCHEME_MAP](https://github.com/rucio/rucio/blob/1b8ca368523d13fd11bc0b32c14528f2fcec778b/lib/rucio/common/constants.py#L48)


### PR DESCRIPTION
fix #472

This was deprecated in https://github.com/rucio/rucio/issues/6163, as part of 1.31.1. The current oldest LTS version is 32, so this is safe to remove.