### PR TITLE
Update clone command for VSCode development environment repository

### DIFF
--- a/docs/developer/setting_up_vscode_dev_env.md
+++ b/docs/developer/setting_up_vscode_dev_env.md
@@ -120,7 +120,7 @@ Whatever route you go, you should have a `hostcert.pem` and a `hostkey.pem` file
   ```
 - Clone the vscode configuration repository
   ```
-  gh repo clone maany/rucio-vscode-dev-env
+  gh repo clone rucio/rucio-vscode-dev-env
   ```
 - Move the vscode repo inside the rucio repo
   ```


### PR DESCRIPTION
Since the rucio-vscode-dev-env is now officially a rucio repository, the documentation needs to be updated to reflect the change.