### PR TITLE
Prepend '/run_in_docker/rucio/lib' to the Python module search path. Fix #414

### DIFF
--- a/tools/run_in_docker/generate_docs.sh
+++ b/tools/run_in_docker/generate_docs.sh
@@ -18,6 +18,8 @@ fi
 
 cp rucio/etc/docker/test/extra/rucio_sqlite.cfg /opt/rucio/etc/rucio.cfg
 
+export PYTHONPATH="/run_in_docker/rucio/lib:${PYTHONPATH}"
+
 "$SCRIPT_DIR"/generate_rest_api_docs.sh
 "$SCRIPT_DIR"/generate_bin_help_docs.sh
 "$SCRIPT_DIR"/generate_client_api_docs.sh


### PR DESCRIPTION
As described in #414, this PR ensures that the local Rucio lib (including possible local changes) are being considered during the documentation build (e.g. for OpenAPI). I think this should solve the problem.