### PR TITLE
Enable additional markdown extensions in mkdocs configuration; Fix #577

### DIFF
--- a/tools/run_in_docker/mkdocs.yml
+++ b/tools/run_in_docker/mkdocs.yml
@@ -26,6 +26,9 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
   - toc:
       permalink: true
 plugins:


### PR DESCRIPTION
As mentioned in #577, couple extra extensions are required for styling nicely python code.