### PR TITLE
Use long-form command options instead of short-form, for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The python dependencies need to be installed. They are defined in
 `requirements.txt`. Install them via:
 
 ```bash
-python3 -m pip install -r tools/requirements.txt
+python3 -m pip install --requirement tools/requirements.txt
 ```
 
 For running the Docusaurus development server, you also need the website

--- a/docs/developer/setting_up_mac_apple_silicon.md
+++ b/docs/developer/setting_up_mac_apple_silicon.md
@@ -30,5 +30,5 @@ Set Docker default platform to `linux/amd64`:
 
 Or run it as part of the command a single time:
 ```bash
-    DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose -f <docker-compose-file.yml>
+    DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose --file <docker-compose-file.yml>
 ```

--- a/docs/developer/testing/fts_and_conveyor.md
+++ b/docs/developer/testing/fts_and_conveyor.md
@@ -8,11 +8,11 @@ To test FTS and the Conveyor, you should start the development environment, incl
 see [Setting up a Rucio demo environment](operator/setting_up_demo.md) for more information.
 
 The required profiles are `storage` (for the FTS and XRD containers) and `iam` (for the token-related Conveyor tests).
-Make sure to pass `-f etc/docker/dev/docker-compose.ports.yml` if you want to access the FTS Web Monitoring UI (see below).
+Make sure to pass `--file etc/docker/dev/docker-compose.ports.yml` if you want to access the FTS Web Monitoring UI (see below).
 The recommended setup command is as follows:
 
 ```sh
-docker compose -f etc/docker/dev/docker-compose.yml -f etc/docker/dev/docker-compose.ports.yml --profile storage --profile iam up -d
+docker compose --file etc/docker/dev/docker-compose.yml --file etc/docker/dev/docker-compose.ports.yml --profile storage --profile iam up --detach
 ```
 
 Once the containers are running, you should initialize the tests.
@@ -38,7 +38,7 @@ To set this up, make sure to pass the `docker-compose.ports.yml` file to the Doc
 
 ```sh
 # Note: specify profiles as well, if needed
-docker compose -f etc/docker/dev/docker-compose.yml -f etc/docker/dev/docker-compose.ports.yml up -d
+docker compose --file etc/docker/dev/docker-compose.yml --file etc/docker/dev/docker-compose.ports.yml up --detach
 ```
 
 Once running, you should be able to access the WebUI locally at https://localhost:8449/fts3/ftsmon/#/.

--- a/docs/operator/administration.md
+++ b/docs/operator/administration.md
@@ -66,7 +66,7 @@ Rucio using a patch file created in the previous section, follow these steps:
 Create a kubernetes secret from the hotfix patch:
 
 ```bash
-kubectl -n rucio create secret generic hotfix-conveyor-poller-patch --from-file=hotfix_conveyor_poller.patch
+kubectl --namespace rucio create secret generic hotfix-conveyor-poller-patch --from-file=hotfix_conveyor_poller.patch
 ```
 
 *Note:* if you have more than one cluster, don't forget to create the

--- a/docs/operator/installing_daemons.md
+++ b/docs/operator/installing_daemons.md
@@ -37,9 +37,9 @@ start a simple `judge-cleaner` daemon using a database on
 `mysql.db` without any additional parameters just run this:
 
 ```bash
-docker run --name=rucio-judge-cleaner \
-  -e RUCIO_CFG_DATABASE_DEFAULT="mysql+pymysql://rucio:rucio@mysql.db/rucio" \
-  -e RUCIO_DAEMON=judge-cleaner \
+docker run --name rucio-judge-cleaner \
+  --env RUCIO_CFG_DATABASE_DEFAULT="mysql+pymysql://rucio:rucio@mysql.db/rucio" \
+  --env RUCIO_DAEMON=judge-cleaner \
   rucio/rucio-daemons
 ```
 
@@ -54,9 +54,9 @@ complete rucio.cfg it can also be mounted. This will then ignore the
 The rucio.cfg is used to configure the database backend and the daemons:
 
 ```bash
-docker run --name=rucio-judge-cleaner \
-  -v /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
-  -e RUCIO_DAEMON=judge-cleaner \
+docker run --name rucio-judge-cleaner \
+  --volume /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
+  --env RUCIO_DAEMON=judge-cleaner \
   rucio/rucio-daemons
 ```
 
@@ -65,10 +65,11 @@ to write to a file you can use `RUCIO_ENABLE_LOGS` like
 this:
 
 ```bash
-docker run --name=rucio-judge-cleaner \
-  -v /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
-  -v /tmp/logs:/var/log/rucio -e RUCIO_DAEMON=judge-cleaner \
-  -e RUCIO_ENABLE_LOGS=True \
+docker run --name rucio-judge-cleaner \
+  --volume /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
+  --volume /tmp/logs:/var/log/rucio \
+  --env RUCIO_DAEMON=judge-cleaner \
+  --env RUCIO_ENABLE_LOGS=True \
   rucio/rucio-daemons
 ```
 

--- a/docs/operator/installing_server.md
+++ b/docs/operator/installing_server.md
@@ -29,7 +29,7 @@ and will be pulled in as necessary.
 A simple server without SSL can be started like this:
 
 ```bash
-docker run --name=rucio-server -p 80:80 -d rucio/rucio-server
+docker run --name rucio-server --publish 80:80 --detach rucio/rucio-server
 ```
 
 This will start up a simple server using sqlite based on an automatically
@@ -52,10 +52,10 @@ container connecting to a MySQL DB running at `mysql.db` you could use something
 like this:
 
 ```bash
-docker run --name=rucio-server \
-  -e RUCIO_CFG_DATABASE_DEFAULT="mysql+pymysql://rucio:rucio@mysql.db/rucio" \
-  -p 80:80 \
-  -d \
+docker run --name rucio-server \
+  --env RUCIO_CFG_DATABASE_DEFAULT="mysql+pymysql://rucio:rucio@mysql.db/rucio" \
+  --publish 80:80 \
+  --detach \
   rucio/rucio-server
 ```
 
@@ -68,10 +68,10 @@ if you have a rucio.cfg ready on your host system under `/tmp/rucio.cfg` you
 could start a container like this:
 
 ```bash
-docker run --name=rucio-server \
-  -v /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
-  -p 80:80 \
-  -d \
+docker run --name rucio-server \
+  --volume /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
+  --publish 80:80 \
+  --detach \
   rucio/rucio-server
 ```
 
@@ -82,14 +82,14 @@ and also need to include the host certificate, key and the the CA certificate as
 volumes. E.g.,:
 
 ```bash
-docker run --name=rucio-server \
-  -v /tmp/ca.pem:/etc/grid-security/ca.pem \
-  -v /tmp/hostcert.pem:/etc/grid-security/hostcert.pem \
-  -v /tmp/hostkey.pem:/etc/grid-security/hostkey.pem \
-  -v /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
-  -p 443:443 \
-  -e RUCIO_ENABLE_SSL=True \
-  -d \
+docker run --name rucio-server \
+  --volume /tmp/ca.pem:/etc/grid-security/ca.pem \
+  --volume /tmp/hostcert.pem:/etc/grid-security/hostcert.pem \
+  --volume /tmp/hostkey.pem:/etc/grid-security/hostkey.pem \
+  --volume /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
+  --publish 443:443 \
+  --env RUCIO_ENABLE_SSL=True \
+  --detach \
   rucio/rucio-server
 ```
 
@@ -99,12 +99,12 @@ the `RUCIO_ENABLE_LOGS` variable. The storage folder of the logs can be used as
 a volume:
 
 ```bash
-docker run --name=rucio-server \
-  -v /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
-  -v /tmp/logs:/var/log/httpd \
-  -p 80:80 \
-  -e RUCIO_ENABLE_LOGS=True \
-  -d \
+docker run --name rucio-server \
+  --volume /tmp/rucio.cfg:/opt/rucio/etc/rucio.cfg \
+  --volume /tmp/logs:/var/log/httpd \
+  --publish 80:80 \
+  --env RUCIO_ENABLE_LOGS=True \
+  --detach \
   rucio/rucio-server
 ```
 

--- a/docs/operator/k8s_guide.md
+++ b/docs/operator/k8s_guide.md
@@ -112,9 +112,9 @@ To bootstrap the db, there are two possibilities:
 
 ```sh
 docker run --rm \
-  -e RUCIO_CFG_DATABASE_DEFAULT="postgresql://rucio:xxx@dbod-rucioitdb.cern.ch:<port>/rucio" \
-  -e RUCIO_CFG_BOOTSTRAP_USERPASS_IDENTITY="admin" \
-  -e RUCIO_CFG_BOOTSTRAP_USERPASS_PWD="xxx" \
+  --env RUCIO_CFG_DATABASE_DEFAULT="postgresql://rucio:xxx@dbod-rucioitdb.cern.ch:<port>/rucio" \
+  --env RUCIO_CFG_BOOTSTRAP_USERPASS_IDENTITY="admin" \
+  --env RUCIO_CFG_BOOTSTRAP_USERPASS_PWD="xxx" \
   rucio/rucio-init
 ```
 

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -49,7 +49,7 @@ Set up a Rucio server for development
 
 ```bash
 git clone https://github.com/rucio/rucio.git
-docker-compose --file etc/docker/dev/docker-compose.yml up -d
+docker-compose --file etc/docker/dev/docker-compose.yml up --detach
 ```
 
 The command will fire up various containers such as `dev-rucio-1`, `dev-graphite-1`, and
@@ -70,7 +70,7 @@ Grafana and enable the graphite data source
 
 ```bash
 docker pull grafana/grafana
-docker run -d --name=grafana -p 3000:3000 grafana/grafana
+docker run --detach --name grafana --publish 3000:3000 grafana/grafana
 ```
 
 The Grafana web-portal is on port 3000 of the host. Add one data source of the
@@ -250,16 +250,16 @@ Next is to setup and configure Elasticsearch and Kibana for storing and
 visualising the messages. This is an example of creating them in containers
 
 ```bash
-docker run -d \
-  -p 9200:9200 \
-  -p 9300:9300 \
-  -e "discovery.type=single-node" \
+docker run --detach \
+  --publish 9200:9200 \
+  --publish 9300:9300 \
+  --env "discovery.type=single-node" \
   --name elasticsearch \
   docker.elastic.co/elasticsearch/elasticsearch:7.8.1
 
-docker run -d \
+docker run --detach \
   --link elasticsearch \
-  -p 5601:5601 \
+  --publish 5601:5601 \
   --name kibana \
   docker.elastic.co/kibana/kibana:7.8.1
 ```
@@ -352,7 +352,7 @@ this after installing the required tools
 pip install --upgrade pip
 pip install elasticsearch
 wget https://files.pythonhosted.org/packages/52/7e/22ca617f61e0d5904e06c1ebd5d453adf30099526c0b64dca8d74fff0cad/stomp.py-4.1.22.tar.gz
-tar -zxvf stomp.py-4.1.22.tar.gz
+tar --extract --gzip --verbose --file stomp.py-4.1.22.tar.gz
 cd stomp.py-4.1.22
 python setup.py install
 ```

--- a/docs/operator/policy_packages/policy_packages_deployment.md
+++ b/docs/operator/policy_packages/policy_packages_deployment.md
@@ -42,7 +42,7 @@ In the `values.yaml` for `server` and `daemons` (and optionally for `ui` / `webu
 1. In the `server`, `clients`, `daemons`, `ui` and `init` containers, pass the `POLICY_PACKAGE_REQUIREMENTS` build argument. Example:
 Example:
 ```
-docker build -t server --build-arg POLICY_PACKAGE_REQUIREMENTS=vo_1_policy_package==0.4.0,git+https://github.com/vo-2/vo-2-policy-package@v0.1.0
+docker build --tag server --build-arg POLICY_PACKAGE_REQUIREMENTS=vo_1_policy_package==0.4.0,git+https://github.com/vo-2/vo-2-policy-package@v0.1.0
 ```
 
 ### Deploying via Kubernetes secret

--- a/docs/operator/setting_up_demo.md
+++ b/docs/operator/setting_up_demo.md
@@ -72,7 +72,7 @@ Run the containers using docker-compose (again might need
 `sudo`):
 
 ```bash
-docker-compose --file etc/docker/dev/docker-compose.yml up -d
+docker-compose --file etc/docker/dev/docker-compose.yml up --detach
 ```
 
 And verify that it is running properly:
@@ -104,9 +104,9 @@ modules, test case groups, or even single test cases, for example:
 
 ```bash
 tools/run_tests.sh -i
-pytest -v --full-trace tests/test_replica.py
-pytest -v --full-trace tests/test_replica.py:TestReplicaCore
-pytest -v --full-trace tests/test_replica.py:TestReplicaCore.test_delete_replicas_from_datasets
+pytest --verbose --full-trace tests/test_replica.py
+pytest --verbose --full-trace tests/test_replica.py:TestReplicaCore
+pytest --verbose --full-trace tests/test_replica.py:TestReplicaCore.test_delete_replicas_from_datasets
 ```
 
 ## Using the environment including storage
@@ -114,7 +114,7 @@ pytest -v --full-trace tests/test_replica.py:TestReplicaCore.test_delete_replica
 Again run the containers using docker-compose:
 
 ```bash
-docker-compose --file etc/docker/dev/docker-compose.yml --profile storage up -d
+docker-compose --file etc/docker/dev/docker-compose.yml --profile storage up --detach
 ```
 
 This should show you a few more running containers: the Rucio server,
@@ -151,7 +151,7 @@ On the second display of the rule, its state has cleared to OK.
 Again run the containers using docker-compose:
 
 ```bash
-docker-compose --file etc/docker/dev/docker-compose.yml --profile storage --profile monitoring up -d
+docker-compose --file etc/docker/dev/docker-compose.yml --profile storage --profile monitoring up --detach
 ```
 
 Now you will have the same containers as before plus a full monitoring
@@ -210,7 +210,7 @@ which defines the ports each service exposes.
 If manually setting up the environment, you just need to pass this extra file on top of the main compose file, e.g. in the following way:
 
 ```sh
-docker-compose --file etc/docker/dev/docker-compose.yml --file etc/docker/dev/docker-compose.ports.yml up -d
+docker-compose --file etc/docker/dev/docker-compose.yml --file etc/docker/dev/docker-compose.ports.yml up --detach
 ```
 
 If using the `bootstrap_dev.sh` script, you can pass the `-x / --expose-ports` flag, e.g.:
@@ -325,14 +325,14 @@ RUN git clone https://github.com/rucio/rucio.git /tmp/rucio
 # to e.g.:
 RUN git clone --single-branch --branch next https://github.com/rucio/rucio.git /tmp/rucio
 #build your docker
-sudo docker build -t rucio/rucio-dev
+sudo docker build --tag rucio/rucio-dev
 ```
 
 Compose as usual using docker-compose:
 
 ```bash
 cd /opt/rucio
-sudo docker-compose --file etc/docker/dev/docker-compose.yml up -d
+sudo docker-compose --file etc/docker/dev/docker-compose.yml up --detach
 ```
 
 Start the daemons


### PR DESCRIPTION
fix #639