### PR TITLE
docs(operator): link daemon Python requirement to central requirement

### DIFF
--- a/docs/operator/installing_daemons.md
+++ b/docs/operator/installing_daemons.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 ## Prerequisites
 
 The Rucio daemons require a supported Python version.
-See the [Python requirements](../started/requirements.md#python) for the currently supported versions.
+See the [Python requirements](started/requirements.md#python) for the currently supported versions.
 
 ## Install via pip
 


### PR DESCRIPTION
This PR resolves #585 by removing hardcoded Python versions from the Rucio daemon prerequisites and linking to the central Python requirements page (https://rucio.cern.ch/documentation/started/requirements/#python), so the documentation stays up to date automatically.