### PR TITLE
Add link to contributing guide to main index

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,6 +2,11 @@
     "docs": [
         "index",
         {
+            "label": "Contributing Guide",
+            "type": "doc",
+            "id": "contributing"
+        },
+        {
             "label": "Getting Started",
             "type": "category",
             "items": [


### PR DESCRIPTION
Main index looks like this now: 

<img width="296" height="291" alt="image" src="https://github.com/user-attachments/assets/03b17660-4e3b-495b-a4d6-45f4eea02d72" />


Closes #717 