### PR TITLE
docs(Documentation): Fix copyright notice

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,7 +76,7 @@ module.exports={
     },
     "footer": {
       "links": [],
-      "copyright": "Copyright © 2023 CERN",
+      "copyright": `Copyright © ${new Date().getFullYear()} CERN`,
       "logo": {
         "src": "img/rucio_horizontaled_black.svg",
         "srcDark": "img/rucio_horizontaled_white.svg"


### PR DESCRIPTION
This PR solves the issue of updating the copyright notice. Instead of hardcoding the year, it now uses `"copyright":` `Copyright © ${new Date().getFullYear()} CERN` so the year updates automatically.

Fixes #715 