### PR TITLE
docs(release-policy, webui): make a note about webui LTS policy

### DIFF
--- a/docs/started/releasepolicy.md
+++ b/docs/started/releasepolicy.md
@@ -118,7 +118,7 @@ consistency and compatibility.
      backward-compatible.
 - **Patch Version**: Incremented for backward-compatible bug fixes.
 
-### WebUI LTS Policy
+#### WebUI LTS Policy
 
 Starting from **release 38**, the Rucio WebUI follows the same LTS strategy as
 the Rucio server. Release 38 is the first WebUI **Long-term Support (LTS)**


### PR DESCRIPTION
 Added a section to `docs/started/releasepolicy.md` describing the WebUI LTS policy, stating that starting from release 38, the WebUI adopts the same LTS strategy as the Rucio server, and clarifying that release 38 is the first WebUI LTS release due to earlier architectural changes and feature gaps.