### PR TITLE
Automatically toggle light/dark mode based on system preference

### DIFF
--- a/tools/run_in_docker/mkdocs.yml
+++ b/tools/run_in_docker/mkdocs.yml
@@ -20,16 +20,22 @@ theme:
     - content.code.copy
     - toc.follow
   palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
     - scheme: default
+      media: "(prefers-color-scheme: light)"
       primary: white
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
+      media: "(prefers-color-scheme: dark)"
       primary: white
       toggle:
         icon: material/brightness-4
-        name: Switch to light mode
+        name: Switch to system preference
 markdown_extensions:
   - admonition
   - pymdownx.details

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -50,6 +50,9 @@ module.exports={
   ],
   "plugins": [],
   "themeConfig": {
+    "colorMode": {
+      "respectPrefersColorScheme": true
+    },
     "navbar": {
       "title": "Rucio Documentation",
       "logo": {


### PR DESCRIPTION
Both [Docusaurus](https://docusaurus.io/docs/api/themes/configuration/#respectPrefersColorScheme) and [MkDocs-Material](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode) support setting the light/dark theme automatically based on the user's `prefers-color-scheme` setting.

This means users who have enabled dark mode by default in their browser don't have to manually switch to dark mode when loading the Rucio documentation.