### PR TITLE
Ignore CTAO homepage, often falses reports dead link

### DIFF
--- a/tools/link-check.json
+++ b/tools/link-check.json
@@ -8,6 +8,9 @@
 	},
 	{
 	    "pattern": "https?://ip:"
+	},
+	{
+	    "pattern": "https://www.ctao.org"
 	}
     ],
 	"retryOn429": true,


### PR DESCRIPTION
[See failed runs](https://github.com/rucio/documentation/actions/workflows/check_external_links.yaml?query=is%3Afailure)