### PR TITLE
Documentation: fix broken navbar API links in docusaurus config #880

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -68,7 +68,7 @@ module.exports={
       },
       "items": [
         {
-          "to": "pathname:///html/client_api/accountclient.html",
+          "to": "pathname://html/client_api/accountclient.html",
           "label": "Python Client API",
           "position": "left"
         },
@@ -78,7 +78,7 @@ module.exports={
           "position": "left"
         },
         {
-          "to": "pathname:///html/rest_api_doc.html",
+          "to": "pathname://html/rest_api_doc.html",
           "label": "REST API",
           "position": "left"
         },


### PR DESCRIPTION
### Summary of Changes

Fixes broken top navigation bar links for the Python Client API and REST API documentation in `website/docusaurus.config.js`.

- Corrected `pathname:///` URL prefix syntax to `pathname://` to ensure relative paths resolve properly on deployed GitHub Pages.

Closes: #880