### PR TITLE
Documentation: add missing trailing slash to baseUrl in docusaurus config #882

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,7 +1,7 @@
 module.exports={
   "title": "Rucio Documentation",
   "url": "https://rucio.github.io",
-  "baseUrl": "/documentation",
+  "baseUrl": "/documentation/",
   "organizationName": "rucio",
   "projectName": "documentation",
   "scripts": [


### PR DESCRIPTION
### Summary of Changes

Adds a missing trailing slash to `baseUrl` in `website/docusaurus.config.js` (`"/documentation/"`).

- Fixes the Docusaurus site configuration warning banner displayed on homepage load.

Closes: #882