### PR TITLE
Ignore km3net website in link check

### DIFF
--- a/tools/link-check.json
+++ b/tools/link-check.json
@@ -11,6 +11,9 @@
 	},
 	{
 	    "pattern": "https://www.ctao.org"
+	},
+	{
+		"pattern": "https://www.km3net.org"
 	}
     ],
 	"retryOn429": true,


### PR DESCRIPTION
The KM3net website is the primary source of false positives on the link check action. I propose we ignore it. 